### PR TITLE
Add test for MapDBVar.toString

### DIFF
--- a/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/db/MapDBContextTest.java
+++ b/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/db/MapDBContextTest.java
@@ -143,4 +143,17 @@ class MapDBContextTest {
     Var<User> changedVar = db.getVar(varName);
     assertEquals(changedVar.get(), USER);
   }
+
+  @Test
+  void testToString() throws Exception {
+    String varName = "somevar";
+    Var<User> var = db.getVar(varName);
+    var.set(CREATOR);
+    db.commit();
+    var = db.getVar(varName);
+    var.set(USER);
+    db.commit();
+    Var<User> changedVar = db.getVar(varName);
+    Assertions.assertEquals("MapDBVar{var=User(id=1, firstName=first, isBot=false, lastName=last, userName=username, languageCode=null, canJoinGroups=false, canReadAllGroupMessages=false, supportInlineQueries=false)}", ((MapDBVar) (changedVar)).toString());
+  }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `changedVar.toString()` is equal to `"MapDBVar{var=User(id=1, firstName=first, isBot=false, lastName=last, userName=username, languageCode=null, canJoinGroups=false, canReadAllGroupMessages=false, supportInlineQueries=false)}"`.
This tests the method [`MapDBVar.toString`](https://github.com/rubenlagus/TelegramBots/blob/622cab39fca56ffc57496a203cbbe00e524cf756/telegrambots-abilities/src/main/java/org/telegram/abilitybots/api/db/MapDBVar.java#L44).
This test is based on the test [`canGetAndSetVariables`](https://github.com/rubenlagus/TelegramBots/blob/622cab39fca56ffc57496a203cbbe00e524cf756/telegrambots-abilities/src/test/java/org/telegram/abilitybots/api/db/MapDBContextTest.java#L131).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))